### PR TITLE
fix: Make GitHub Actions workflow more robust

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -25,10 +25,19 @@ jobs:
     - name: Build with Gradle
       run: ./gradlew assembleRelease
 
+    - name: List output files
+      run: ls -R app/build/outputs/apk/release/
+
     - name: Rename APK
       run: |
         commit_hash=$(git rev-parse --short HEAD)
-        mv app/build/outputs/apk/release/app-release.apk app/build/outputs/apk/release/AgentC-release-${commit_hash}.apk
+        apk_file=$(find app/build/outputs/apk/release -name "*.apk" | head -n 1)
+        if [ -f "$apk_file" ]; then
+          mv "$apk_file" "app/build/outputs/apk/release/AgentC-release-${commit_hash}.apk"
+        else
+          echo "No APK file found to rename."
+          exit 1
+        fi
 
     - name: Upload APK
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
> This commit makes the GitHub Actions workflow more robust by adding a step to list the contents of the build output directory and by modifying the rename step to find and rename any generated APK file.

This will help in debugging the build process and make the workflow less brittle.