### PR TITLE
Analyze and fix android ci workflow

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -13,17 +13,17 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'temurin'
         cache: gradle
 
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build with Gradle
-      run: ./gradlew assembleRelease > build.log 2>&1 || true
+      run: ./gradlew :app:assembleRelease > build.log 2>&1 || true
 
     - name: Upload build log
       uses: actions/upload-artifact@v4

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.android.application'
+    id 'com.android.application' version '7.3.1'
 }
 
 android {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,10 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+rootProject.name = 'AgentC'
+include ':app'


### PR DESCRIPTION
Fix Android CI workflow by configuring Gradle and updating the build environment to resolve build failures.

The previous workflow failed because Gradle could not find the Android plugin, the build used an incorrect Java version (JDK 11 instead of 17), and the `assembleRelease` task was called without specifying the `app` module. This PR adds the necessary `settings.gradle` file, specifies the Android Gradle Plugin version, and updates the CI workflow to use JDK 17 and the correct Gradle task.

---
<a href="https://cursor.com/background-agent?bcId=bc-f0d1e8ab-bd82-48ed-96ba-335c5e6e7d36">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f0d1e8ab-bd82-48ed-96ba-335c5e6e7d36">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>